### PR TITLE
Also allow install_to_lib and install_to_include

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-ament-build"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Nikolai Morin <nnmmgit@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,4 +16,6 @@ install_to_share = ["launch", "config"]
 ```
 These paths are relative to the directory containing the `Cargo.toml` file and will be copied to the appropriate location in `share`.
 
+The same mechanism applies with `install_to_include` and `install_to_lib`.
+
 Target types other than libraries and binaries (i.e. benches, tests) are not yet installed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn fallible_main() -> Result<bool> {
         // Unwrap is safe since complete_from_path() has been called
         &manifest.bin.unwrap(),
     )?;
-    install_to_share(
+    install_files_from_metadata(
         &args.install_base,
         package_path,
         package_name,


### PR DESCRIPTION
This will always install to `prefix/lib/package_name`, and same with include.

See also https://github.com/ros2-rust/cargo-ament-build/issues/1#issuecomment-1128181399