### PR TITLE
Add extension for windows binaries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,10 @@ pub fn install_binaries(
             .ok_or(anyhow!("Binary without name found"))?;
         let src = src_dir.join(name);
         let dest = dest_dir.join(name);
+        #[cfg(target_os = "windows")]
+        let dest = dest.with_extension("exe");
+        #[cfg(target_os = "windows")]
+        let src = src.with_extension("exe");
         // Create destination directory
         DirBuilder::new().recursive(true).create(&dest_dir)?;
         std::fs::copy(&src, &dest)


### PR DESCRIPTION
Binaries on windows have a `.exe` extension, the library does not take that into account and file copy fails when trying to copy binaries.

This PR just adds cfg flag to add a `.exe` to both source and destination path for binaries on windows.

For more background in this PR and how to validate it https://github.com/colcon/colcon-ros-cargo/pull/22#issuecomment-2306087237