### PR TITLE
Remove macos 12 from CI

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-14
             target: x86_64
           - runner: macos-14
             target: aarch64


### PR DESCRIPTION
macOS 12 has been removed as a GitHub runner according to https://github.com/actions/runner-images/issues/10721