### PR TITLE
Add support for cross-compiled binaries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn fallible_main() -> Result<bool> {
         &args.build_base,
         package_name,
         &args.profile,
+        args.arch.as_deref(),
         // Unwrap is safe since complete_from_path() has been called
         &manifest.bin,
     )?;


### PR DESCRIPTION
Cargo puts cross-compiled binaries in an additional subdirectory; for example:

native: `target/debug`
vs
arm64: `target/aarch64-unknown-linux-gnu/debug`

For this reason, cargo-ament-build fails when cross compiling:
```
Starting >>> publ
--- stderr: publ
Error in cargo-ament-build

Caused by:
0: Failed to copy binary from '/workspace/build/publ/debug/publ'
1: No such file or directory (os error 2)
---
Failed   <<< publ [5.09s, exited with code 1]
```

This change introduces detection of the build target architecture via the `--target` argument or the `CARGO_BUILD_TARGET` environment variable and modifies the search path for binaries accordingly.