### PR TITLE
Remove custom runners from dist action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,3 @@ ci = "github"
 installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
-
-[workspace.metadata.dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
-aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"


### PR DESCRIPTION
Our latest release [failed](https://github.com/ros2-rust/cargo-ament-build/actions/runs/20447726363/job/58754443686) because the linux `aarch64` runners are using a very old rust version.
I'm not sure why we are using custom runners, it seems the default github runners do have the latest rust, CC @esteve since you set up the action in the first place?

The sad part is that since `dist` only triggers on new tags being pushed, this change won't actually be tested by the CI in this PR.