### PR TITLE
fix: Bump cargo-manifest version to be compatible with 2024 edition workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["ros2", "colcon", "ament"]
 
 [dependencies]
 anyhow = "1"
-cargo-manifest = "0.17"
+cargo-manifest = "0.19"
 pico-args = "0.4"
 
 # The profile that 'cargo dist' will build with


### PR DESCRIPTION
I have a cargo workspace in which I also want to use rclrs. I am using edition 2024 with resolver v3:
```toml
[workspace]
resolver = "3"

[workspace.package]
edition = "2024"
```

With the current version of `cargo-ament-build`, I am getting a parser error:

```
$ cargo ament-build -p rust_pubsub --install-base install 
Error in cargo-ament-build

Caused by:
    TOML parse error at line 2, column 12
      |
    2 | resolver = "3"
      |            ^^^
    unknown variant `3`, expected `1` or `2`
```

A potential workaround is to not specify the `resolver` in this file as [it is implicitly defined in the version 2024](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html#summary). However, I still think that this tool should not break existing setups, so this is not a solution for me. `cargo-manifest` v0.18.0 added support for `resolver = "3"`: https://github.com/LukeMathWalker/cargo-manifest/blob/master/CHANGELOG.md#v0180-2025-01-10, so the proper fix is to bump this dependency. As I am already bumping this dependency version, I opted to use the latest version rather than the lowest one that addresses this issue. 

Note that I am aware of the failing CI check named `Security audit / security_audit (push)` on this dependency, but by sweeping the commits I couldn't find anything sus (e.g. new dependencies), and it seems to be a failing [cargo-deny-action](https://github.com/EmbarkStudios/cargo-deny-action) run based on [this config](https://github.com/LukeMathWalker/cargo-manifest/blob/master/deny.toml).

This PR resolves the current issue and I can build now with the workspace:
```
$ ./src/experiments/cargo-ament-build/target/debug/cargo-ament-build --install-base install

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
```

I didn't perform any other tests.


Caveat:
The current `cargo-ament-build` still doesn't support workspaces (and likely wasn't intended to?) so this PR only resolves one issue with them, but the steps following the `cargo build` are still failing:
```
Error in cargo-ament-build

Caused by:
    Cargo manifest has no package section.
```
This is out of scope. 
