### PR TITLE
test: Introduce some unit tests for the lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,21 @@ anyhow = "1"
 cargo-manifest = "0.17"
 pico-args = "0.4"
 
+[dev-dependencies]
+tempfile = { version = "3" }
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
 lto = "thin"
 
-# Config for 'dist'
-[workspace.metadata.dist]
-# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.3"
-# CI backends to support
-ci = "github"
-# The installers to generate for each app
-installers = []
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+# # Config for 'dist'
+# [workspace.metadata.dist]
+# # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+# cargo-dist-version = "0.30.3"
+# # CI backends to support
+# ci = "github"
+# # The installers to generate for each app
+# installers = []
+# # Target platforms to build apps for (Rust target-triple syntax)
+# targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,13 @@ tempfile = { version = "3" }
 inherits = "release"
 lto = "thin"
 
-# # Config for 'dist'
-# [workspace.metadata.dist]
-# # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-# cargo-dist-version = "0.30.3"
-# # CI backends to support
-# ci = "github"
-# # The installers to generate for each app
-# installers = []
-# # Target platforms to build apps for (Rust target-triple syntax)
-# targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+# Config for 'dist'
+[workspace.metadata.dist]
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.30.3"
+# CI backends to support
+ci = "github"
+# The installers to generate for each app
+installers = []
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,4 +484,48 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_install_binaries_lib_variants() -> Result<()> {
+        let tmp = tempdir()?;
+        let build_base = tmp.path().join("target");
+        let install_base = tmp.path().join("install");
+        let package_name = "my_rust_lib";
+        let profile = "release";
+
+        let src_dir = build_base.join(profile);
+        std::fs::create_dir_all(&src_dir)?;
+
+        let so_path = src_dir.join("libmy_rust_lib.so");
+        let a_path = src_dir.join("libmy_rust_lib.a");
+        let dll_path = src_dir.join("my_rust_lib.dll");
+        let lib_path = src_dir.join("my_rust_lib.lib");
+        let dylib_path = src_dir.join("libmy_rust_lib.dylib");
+
+        File::create(&so_path)?;
+        File::create(&a_path)?;
+        File::create(&dll_path)?;
+        File::create(&lib_path)?;
+        File::create(&dylib_path)?;
+
+        install_binaries(
+            &install_base,
+            &build_base,
+            package_name,
+            profile,
+            None,
+            &HashSet::new(),
+            &[],
+        )?;
+
+        let dest_dir = install_base.join("lib").join(package_name);
+
+        assert!(dest_dir.join("libmy_rust_lib.so").exists());
+        assert!(dest_dir.join("libmy_rust_lib.a").exists());
+        assert!(dest_dir.join("my_rust_lib.dll").exists());
+        assert!(dest_dir.join("my_rust_lib.lib").exists());
+        assert!(dest_dir.join("libmy_rust_lib.dylib").exists());
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ pub fn create_package_marker(
     Ok(())
 }
 
-/// Copies files or directories.
+/// Copies files or directories recursively.
 fn copy(src: impl AsRef<Path>, dest_dir: impl AsRef<Path>) -> Result<()> {
     let src = src.as_ref();
     let dest = dest_dir.as_ref().join(src.file_name().unwrap());
@@ -361,6 +361,8 @@ pub fn install_files_from_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
+    use std::io::Write;
     use tempfile::tempdir;
 
     #[test]
@@ -375,6 +377,25 @@ mod tests {
 
         assert!(marker_path.exists());
         assert!(marker_path.is_file());
+        Ok(())
+    }
+
+    #[test]
+    fn test_copy_recursive() -> Result<()> {
+        let tmp = tempdir()?;
+        let src_dir = tmp.path().join("src_folder");
+        let dest_dir = tmp.path().join("dest_folder");
+
+        std::fs::create_dir_all(src_dir.join("sub"))?;
+        File::create(src_dir.join("file.txt"))?.write_all(b"hello")?;
+        File::create(src_dir.join("sub/inner.txt"))?.write_all(b"world")?;
+
+        std::fs::create_dir_all(&dest_dir)?;
+
+        copy(&src_dir, &dest_dir)?;
+
+        assert!(dest_dir.join("src_folder/file.txt").exists());
+        assert!(dest_dir.join("src_folder/sub/inner.txt").exists());
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,4 +444,44 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_install_binaries_with_arch() -> Result<()> {
+        let tmp = tempdir()?;
+        let build_base = tmp.path().join("target");
+        let install_base = tmp.path().join("install");
+        let package_name = "arch_test";
+        let profile = "debug";
+        let arch = "x86_64-unknown-linux-gnu";
+
+        let src_dir_x86 = build_base.join(arch).join(profile);
+        let src_dir_aarch = build_base.join("aarch64-unknown-linux-gnu").join(profile);
+        std::fs::create_dir_all(&src_dir_x86)?;
+        std::fs::create_dir_all(&src_dir_aarch)?;
+
+        std::fs::write(src_dir_x86.join("libarch_test.so"), "x86")?;
+        std::fs::write(src_dir_aarch.join("libarch_test.so"), "aarch")?;
+
+        install_binaries(
+            &install_base,
+            &build_base,
+            package_name,
+            profile,
+            Some(arch),
+            &HashSet::new(),
+            &[],
+        )?;
+
+        let dest_file = install_base
+            .join("lib")
+            .join(package_name)
+            .join("libarch_test.so");
+
+        assert!(dest_file.exists());
+
+        let installed_content = std::fs::read_to_string(dest_file)?;
+        assert_eq!(installed_content, "x86");
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,15 @@ pub fn cargo(args: &[OsString], verb: &str) -> Result<Option<i32>> {
     Ok(exit_status.code())
 }
 
-/// This is comparable to ament_index_register_resource() in CMake
+/// Create an ament resource index marker file for a package
+///
+/// This function registers a package to ament by creating an empty marker file at
+/// `share/ament_index/resource_index` with the package name as filename.  
+///
+/// The presence of this file is used by ament and colcon to discover installed packages and other resources.
+/// For more information:
+/// - Design doc: https://github.com/ament/ament_cmake/blob/2366f15479e37d552d4e225f09ccef1c6ccc8c4e/ament_cmake_core/doc/resource_index.md
+/// - Reference implementation of CMake: https://github.com/ament/ament_cmake/blob/2366f15479e37d552d4e225f09ccef1c6ccc8c4e/ament_cmake_core/cmake/index/ament_index_register_resource.cmake
 pub fn create_package_marker(
     install_base: impl AsRef<Path>,
     marker_dir: &str,
@@ -348,4 +356,25 @@ pub fn install_files_from_metadata(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_create_package_marker() -> Result<()> {
+        let tmp = tempdir()?;
+        let install_base = tmp.path();
+
+        create_package_marker(install_base, "packages", "test_package")?;
+
+        let marker_path =
+            install_base.join("share/ament_index/resource_index/packages/test_package");
+
+        assert!(marker_path.exists());
+        assert!(marker_path.is_file());
+        Ok(())
+    }
 }


### PR DESCRIPTION
Introduce unit tests for the majority of the functions in the library. Only the happy path is tested with a (hopefully) minimum set of unit tests. Also updated the docstring of `create_package_marker` to point to more information for future maintainers. The following is not tested:

- `install_package`: Strange function that IMO shouldn't be there. Asked about it [in the chat](https://matrix.to/#/!AiYXdTWExqamTdatBl:matrix.org/$1G_iFjfh-Ljdf0aO5Q4_63TMH2HtFUSZ9tO4W18y-pk?via=matrix.org&via=uni-osnabrueck.de&via=attendees.fosdem.org) and it can hopefully be removed. Follow-up PR can add test if the consensus is to keep it
- argument parsing: Harder to test, and there's an open issue to move to `clap`. Should be a separate PR
- `cargo`: Introducing a mock should be a separate PR

The rationale for adding these tests is that future refactoring (in particular make it work with cargo workspaces) benefits from having at least _some_ tests. In addition, introducing any test in my experience also lowers the barrier for other people to test their changes.

This PR can be reviewed commit-by-commit, but the general diff should be digestible on its own.

Note: AI was used in the creation of this PR. 

Follow-up work should probably add a `cargo test` to the CI. 