### PR TITLE
Skip Generating Marker File for Reexported Crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ anyhow = "1"
 cargo-manifest = "0.17"
 pico-args = "0.4"
 
+# Pinning a transitive dependency of cargo-manifest to the last major version that could build with rust 1.75
+indexmap = "=2.11.0"
+
 [dev-dependencies]
 tempfile = { version = "3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ anyhow = "1"
 cargo-manifest = "0.17"
 pico-args = "0.4"
 
-# Pinning a transitive dependency of cargo-manifest to the last major version that could build with rust 1.75
-indexmap = "=2.11.0"
-
 [dev-dependencies]
 tempfile = { version = "3" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,17 +65,17 @@ fn fallible_main() -> Result<bool> {
     // we create less garbage if the build command failed.
     create_package_marker(&args.install_base, "packages", package_name)?;
 
-    // If this package should be re-exported by rclrs, we do not want `colcon-ros-cargo` to
+    // If this package should be included in ros-env, we do not want `colcon-ros-cargo` to
     // find the package as it should not be patched.
-    let reexport_rclrs = package
+    let include_ros_env = package
         .metadata
         .as_ref()
-        .and_then(|m| m.get("rclrs"))
-        .and_then(|r| r.get("reexport"))
-        .and_then(|v| v.as_bool())
+        .and_then(|metadata| metadata.get("ros-env"))
+        .and_then(|ros_env| ros_env.get("include"))
+        .and_then(|include| include.as_bool())
         .unwrap_or(false);
 
-    if !reexport_rclrs {
+    if !include_ros_env {
         // This marker is used by colcon-ros-cargo when looking for dependencies
         create_package_marker(&args.install_base, "rust_packages", package_name)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,22 @@ fn fallible_main() -> Result<bool> {
     // Putting marker file creation after the actual build command means that
     // we create less garbage if the build command failed.
     create_package_marker(&args.install_base, "packages", package_name)?;
-    // This marker is used by colcon-ros-cargo when looking for dependencies
-    create_package_marker(&args.install_base, "rust_packages", package_name)?;
+
+    // If this package should be re-exported by rclrs, we do not want `colcon-ros-cargo` to
+    // find the package as it should not be patched.
+    let reexport_rclrs = package
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("rclrs"))
+        .and_then(|r| r.get("reexport"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if !reexport_rclrs {
+        // This marker is used by colcon-ros-cargo when looking for dependencies
+        create_package_marker(&args.install_base, "rust_packages", package_name)?;
+    }
+
     install_package(
         &args.install_base,
         package_path,


### PR DESCRIPTION
As part of the changes required for https://github.com/ros2-rust/ros2_rust/pull/556, we now skip generating the `rust_packages` marker file in the ament index. This effectively prevents any reexported crate from being patched in the `.cargo/config.toml`.